### PR TITLE
fix(version): String and BaseVersion panic with no release parts

### DIFF
--- a/version.go
+++ b/version.go
@@ -282,9 +282,11 @@ func (v Version) String() string {
 	}
 
 	// Release segment
-	fmt.Fprintf(&buf, "%d", v.release[0])
-	for _, r := range v.release[1:len(v.release)] {
-		fmt.Fprintf(&buf, ".%d", r)
+	if len(v.release) != 0 {
+		fmt.Fprintf(&buf, "%d", v.release[0])
+		for _, r := range v.release[1:] {
+			fmt.Fprintf(&buf, ".%d", r)
+		}
 	}
 
 	// Pre-release
@@ -320,9 +322,11 @@ func (v Version) BaseVersion() string {
 	}
 
 	// Release segment
-	fmt.Fprintf(&buf, "%d", v.release[0])
-	for _, r := range v.release[1:len(v.release)] {
-		fmt.Fprintf(&buf, ".%d", r)
+	if len(v.release) != 0 {
+		fmt.Fprintf(&buf, "%d", v.release[0])
+		for _, r := range v.release[1:] {
+			fmt.Fprintf(&buf, ".%d", r)
+		}
 	}
 
 	return buf.String()

--- a/version_test.go
+++ b/version_test.go
@@ -226,6 +226,10 @@ func TestVersion_String(t *testing.T) {
 			assert.Equal(t, tt.want, v.String())
 		})
 	}
+	t.Run("Zero Value", func(t *testing.T) {
+		v := version.Version{}
+		assert.Equal(t, "", v.String())
+	})
 }
 
 func TestVersion_LessThan_LessThanOrEqual(t *testing.T) {


### PR DESCRIPTION
For example, when stringifying a zero value Version.