### PR TITLE
chore: add dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"
+    commit-message:
+      prefix: "chore"
+      include: "scope" 


### PR DESCRIPTION
Add Dependabot configuration to automatically update dependencies.

This configuration:
  - Updates dependencies weekly
  - Groups all dependency updates into a single PR
  - Limits the number of open PRs to 10