### PR TITLE
feat(specifier): add WithLocalVersion option for strict local version comparison

### DIFF
--- a/specifier_option.go
+++ b/specifier_option.go
@@ -1,8 +1,8 @@
 package version
 
 type conf struct {
-	includePreRelease bool
-	allowLocalVersion bool
+	includePreRelease   bool
+	allowLocalSpecifier bool
 }
 
 type SpecifierOption interface {
@@ -15,8 +15,13 @@ func (o WithPreRelease) apply(c *conf) {
 	c.includePreRelease = bool(o)
 }
 
-type WithLocalVersion bool
+// AllowLocalSpecifier is an option that allows local version labels in specifiers.
+// By default (PEP 440), local versions are not permitted in specifiers and local version
+// labels are ignored when checking if candidate versions match a given specifier.
+// When enabled, specifiers like ">= 1.0+local.1" become valid and local version
+// segments are compared strictly.
+type AllowLocalSpecifier bool
 
-func (o WithLocalVersion) apply(c *conf) {
-	c.allowLocalVersion = bool(o)
+func (o AllowLocalSpecifier) apply(c *conf) {
+	c.allowLocalSpecifier = bool(o)
 }

--- a/specifier_option.go
+++ b/specifier_option.go
@@ -2,6 +2,7 @@ package version
 
 type conf struct {
 	includePreRelease bool
+	allowLocalVersion bool
 }
 
 type SpecifierOption interface {
@@ -12,4 +13,10 @@ type WithPreRelease bool
 
 func (o WithPreRelease) apply(c *conf) {
 	c.includePreRelease = bool(o)
+}
+
+type WithLocalVersion bool
+
+func (o WithLocalVersion) apply(c *conf) {
+	c.allowLocalVersion = bool(o)
 }

--- a/specifier_test.go
+++ b/specifier_test.go
@@ -357,7 +357,7 @@ func TestVersion_CheckWithPreRelease(t *testing.T) {
 	}
 }
 
-func TestVersion_CheckWithLocalVersion(t *testing.T) {
+func TestVersion_CheckAllowLocalSpecifier(t *testing.T) {
 	tests := []struct {
 		name    string
 		version string
@@ -416,7 +416,7 @@ func TestVersion_CheckWithLocalVersion(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c, err := NewSpecifiers(tt.spec, WithLocalVersion(true))
+			c, err := NewSpecifiers(tt.spec, AllowLocalSpecifier(true))
 			require.NoError(t, err)
 
 			v, err := Parse(tt.version)
@@ -427,26 +427,26 @@ func TestVersion_CheckWithLocalVersion(t *testing.T) {
 	}
 }
 
-func TestWithLocalVersion_SpecifierValidation(t *testing.T) {
+func TestAllowLocalSpecifier_SpecifierValidation(t *testing.T) {
 	tests := []struct {
 		name    string
 		spec    string
 		wantErr bool
 	}{
-		// These should work with WithLocalVersion
+		// These should work with AllowLocalSpecifier
 		{"gte with local", ">= 1.0+local", false},
 		{"lte with local", "<= 1.0+local", false},
 		{"gt with local", "> 1.0+local", false},
 		{"lt with local", "< 1.0+local", false},
 		{"compatible with local", "~= 1.0+local", false},
 
-		// These already work without WithLocalVersion
+		// These already work without AllowLocalSpecifier
 		{"eq with local", "== 1.0+local", false},
 		{"ne with local", "!= 1.0+local", false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := NewSpecifiers(tt.spec, WithLocalVersion(true))
+			_, err := NewSpecifiers(tt.spec, AllowLocalSpecifier(true))
 			if tt.wantErr {
 				assert.Error(t, err)
 			} else {

--- a/version_test.go
+++ b/version_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/aquasecurity/go-pep440-version"
+	version "github.com/aquasecurity/go-pep440-version"
 )
 
 var (

--- a/version_test.go
+++ b/version_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	version "github.com/aquasecurity/go-pep440-version"
+	"github.com/aquasecurity/go-pep440-version"
 )
 
 var (


### PR DESCRIPTION
 ## Summary                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                  
  Add `WithLocalVersion` option to enable strict local version comparison in specifiers. This extends PEP 440 behavior to allow local versions in range operators (`>=`, `<=`, `>`, `<`, `~=`) and enables strict local version matching.         
                                                                                                                                                                                                                                                  
  ## Motivation                                                                                                                                                                                                                                   
                                                                                                                                                                                                                                                  
  Some users need to compare versions with local segments in ranges, e.g.:                                                                                                                                                                        
                                                                                                                                                                                                                                                  
  ```go                                                                                                                                                                                                                                           
  spec, _ := version.NewSpecifiers(">= 3.2.25+local.1, < 4.0.0", version.WithLocalVersion(true))
```

This is not allowed by PEP 440, but is useful for internal versioning schemes.                                                                                                                                                                  
                                                                                                                                                                                                                                                  
## Usage                                                                                                                                                                                                                                           
```Go                                                                                                                                                                                         
  spec, err := version.NewSpecifiers(
      ">= 3.2.25+local.1, < 4.0.0",
      version.WithLocalVersion(true), 
  )

  v1, _ := version.Parse("3.2.25+local.2")
  spec.Check(v1) // true - local.2 >= local.1

  v2, _ := version.Parse("3.2.25+local.0")
  spec.Check(v2) // false - local.0 < local.1
```                                                                                                                                                                                                          
## Behavior                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                  
### Specifier Validation
```
┌──────────────┬────────────────┬─────────────────────────────┐                                                                                                                                                                                 
  │   Operator   │ Without option │ With WithLocalVersion(true) │                                                                                                                                                                                 
  ├──────────────┼────────────────┼─────────────────────────────┤                                                                                                                                                                                 
  │ >= 1.0+local │ ❌ Error       │ ✅ Allowed                  │                                                                                                                                                                                 
  ├──────────────┼────────────────┼─────────────────────────────┤                                                                                                                                                                                 
  │ <= 1.0+local │ ❌ Error       │ ✅ Allowed                  │                                                                                                                                                                                 
  ├──────────────┼────────────────┼─────────────────────────────┤                                                                                                                                                                                 
  │ > 1.0+local  │ ❌ Error       │ ✅ Allowed                  │                                                                                                                                                                                 
  ├──────────────┼────────────────┼─────────────────────────────┤                                                                                                                                                                                 
  │ < 1.0+local  │ ❌ Error       │ ✅ Allowed                  │                                                                                                                                                                                 
  ├──────────────┼────────────────┼─────────────────────────────┤                                                                                                                                                                                 
  │ ~= 1.0+local │ ❌ Error       │ ✅ Allowed                  │                                                                                                                                                                                 
  ├──────────────┼────────────────┼─────────────────────────────┤                                                                                                                                                                                 
  │ == 1.0+local │ ✅ Allowed     │ ✅ Allowed                  │                                                                                                                                                                                 
  ├──────────────┼────────────────┼─────────────────────────────┤                                                                                                                                                                                 
  │ != 1.0+local │ ✅ Allowed     │ ✅ Allowed                  │                                                                                                                                                                                 
  └──────────────┴────────────────┴─────────────────────────────┘       
```
### Equality Comparison (==, !=)                                                                                                                                                                                                                    
  ```
┌───────────────┬──────────────────┬────────────────┬─────────────┐                                                                                                                                                                             
  │    Version    │    Specifier     │ Without option │ With option │                                                                                                                                                                             
  ├───────────────┼──────────────────┼────────────────┼─────────────┤                                                                                                                                                                             
  │ 2.0.0+local   │ == 2.0.0         │ ✅ match       │ ❌ no match │                                                                                                                                                                             
  ├───────────────┼──────────────────┼────────────────┼─────────────┤                                                                                                                                                                             
  │ 2.0.0         │ == 2.0.0+local   │ ❌ no match    │ ❌ no match │                                                                                                                                                                             
  ├───────────────┼──────────────────┼────────────────┼─────────────┤                                                                                                                                                                             
  │ 2.0.0+local   │ == 2.0.0+local   │ ✅ match       │ ✅ match    │                                                                                                                                                                             
  ├───────────────┼──────────────────┼────────────────┼─────────────┤                                                                                                                                                                             
  │ 2.0.0+local.1 │ == 2.0.0+local.2 │ ❌ no match    │ ❌ no match │                                                                                                                                                                             
  ├───────────────┼──────────────────┼────────────────┼─────────────┤                                                                                                                                                                             
  │ 2.0.0+local   │ != 2.0.0         │ ❌ no match    │ ✅ match    │                                                                                                                                                                             
  └───────────────┴──────────────────┴────────────────┴─────────────┘  
```
### Range Operators (>=, <=, >, <)                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                  
  With WithLocalVersion(true):       
```                                                                                                                                                                                                             
  ┌────────────────┬───────────────────┬─────────────┐                                                                                                                                                                                            
  │    Version     │     Specifier     │   Result    │                                                                                                                                                                                            
  ├────────────────┼───────────────────┼─────────────┤                                                                                                                                                                                            
  │ 3.2.25+local.1 │ >= 3.2.25+local.1 │ ✅ match    │                                                                                                                                                                                            
  ├────────────────┼───────────────────┼─────────────┤                                                                                                                                                                                            
  │ 3.2.25+local.2 │ >= 3.2.25+local.1 │ ✅ match    │                                                                                                                                                                                            
  ├────────────────┼───────────────────┼─────────────┤                                                                                                                                                                                            
  │ 3.2.25+local.0 │ >= 3.2.25+local.1 │ ❌ no match │                                                                                                                                                                                            
  ├────────────────┼───────────────────┼─────────────┤                                                                                                                                                                                            
  │ 3.2.25         │ >= 3.2.25+local.1 │ ❌ no match │                                                                                                                                                                                            
  ├────────────────┼───────────────────┼─────────────┤                                                                                                                                                                                            
  │ 3.2.26         │ >= 3.2.25+local.1 │ ✅ match    │                                                                                                                                                                                            
  └────────────────┴───────────────────┴─────────────┘      
```
## Backward Compatibility
Default behavior (without option) remains unchanged and fully PEP 440 compliant.                                                                                                                                                                
                                                                              