### PR TITLE
fix(version): normalize local version separators

### DIFF
--- a/version.go
+++ b/version.go
@@ -13,7 +13,8 @@ import (
 
 var (
 	// The compiled regular expression used to test the validity of a version.
-	versionRegex *regexp.Regexp
+	versionRegex           *regexp.Regexp
+	localVersionSeparators = strings.NewReplacer("-", ".", "_", ".")
 
 	// https://github.com/pypa/packaging/blob/a6407e3a7e19bd979e93f58cfc7f6641a7378c46/packaging/version.py#L459-L464
 	preReleaseAliases = map[string]string{
@@ -145,7 +146,7 @@ func Parse(v string) (Version, error) {
 		case "dev_n":
 			devN, err = part.NewUint64(m)
 		case "local":
-			local = strings.ToLower(m)
+			local = localVersionSeparators.Replace(strings.ToLower(m))
 		}
 		if err != nil {
 			return Version{}, xerrors.Errorf("failed to parse version (%s): %w", v, err)

--- a/version_test.go
+++ b/version_test.go
@@ -206,6 +206,9 @@ func TestVersion_String(t *testing.T) {
 		{"1.0-rev5", "1.0.post5"},
 		// Local version case insensitivity
 		{"1.0+AbC", "1.0+abc"},
+		// Local version separator normalization
+		{"1.0+ubuntu-1", "1.0+ubuntu.1"},
+		{"1.0+ubuntu_1", "1.0+ubuntu.1"},
 		// Integer Normalization
 		{"1.01", "1.1"},
 		{"1.0a05", "1.0a5"},
@@ -283,6 +286,22 @@ func TestVersion_Equal(t *testing.T) {
 			assert.True(t, v1.Equal(v2))
 		})
 	}
+}
+
+func TestVersion_LocalVersionSeparators(t *testing.T) {
+	canonical := version.MustParse("1.0+ubuntu.1")
+	for _, original := range []string{"1.0+ubuntu-1", "1.0+ubuntu_1", "1.0+ubuntu.1"} {
+		t.Run(original, func(t *testing.T) {
+			parsed := version.MustParse(original)
+
+			assert.True(t, canonical.Equal(parsed))
+			assert.Equal(t, original, parsed.Original())
+		})
+	}
+
+	lower := version.MustParse("1.0+ubuntu-2")
+	higher := version.MustParse("1.0+ubuntu-10")
+	assert.True(t, lower.LessThan(higher))
 }
 
 func TestVersion_GreaterThan(t *testing.T) {


### PR DESCRIPTION
## Summary

- Normalize `-` and `_` separators in local version labels to the canonical `.` form during parsing.
- Preserve the original input through `Version.Original()`.
- Add tests for canonical output, separator equivalence, and numeric local-segment ordering.

## Rationale

PEP 440 accepts `.`, `-`, and `_` as local version segment separators, with `.` as the normalized form. The parser currently accepts all three forms but only splits on `.` when constructing comparison keys. As a result, equivalent versions can compare differently, and numeric segments following `-` or `_` can be compared lexicographically instead of numerically.

Specification: https://packaging.python.org/en/latest/specifications/version-specifiers/#local-version-segments

## Testing

- `go test ./...`
- `go vet ./...`
- `golangci-lint run`

Closes #15.