### PR TITLE
fix(version): reject non-ASCII version characters

### DIFF
--- a/version.go
+++ b/version.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+	"unicode"
 
 	"golang.org/x/xerrors"
 
@@ -99,6 +100,12 @@ func MustParse(v string) Version {
 
 // Parse parses the given version and returns a new Version.
 func Parse(v string) (Version, error) {
+	for _, r := range v {
+		if r > unicode.MaxASCII {
+			return Version{}, xerrors.Errorf("malformed version: %s", v)
+		}
+	}
+
 	matches := versionRegex.FindStringSubmatch(v)
 	if matches == nil {
 		return Version{}, xerrors.Errorf("malformed version: %s", v)

--- a/version_test.go
+++ b/version_test.go
@@ -93,6 +93,8 @@ func TestParseInvalidVersion(t *testing.T) {
 		"1.0+_foobar",
 		"1.0+foo&asd",
 		"1.0+1+1",
+		"1.0+ſ",
+		"1.0+K",
 	}
 	for _, v := range versions {
 		t.Run(v, func(t *testing.T) {


### PR DESCRIPTION
## Summary

- Reject non-ASCII characters before applying the case-insensitive version regex.
- Add regression coverage for Unicode characters that Go case-folds into the ASCII range.

## Rationale

PEP 440 version syntax is ASCII-only. The parser currently applies Go's global `(?i)` regexp flag to `[a-z]` character classes. Go uses Unicode simple case folding for case-insensitive matching, which causes characters such as `ſ` and `K` to be accepted in local version labels.

Rejecting non-ASCII input before regexp matching preserves case-insensitive handling for valid ASCII syntax while preventing Unicode case-fold equivalents from being treated as valid version characters.

Closes #13.

Specification: https://packaging.python.org/en/latest/specifications/version-specifiers/#local-version-identifiers

## Testing

- `go test ./...`
- `go vet ./...`
- `golangci-lint run`